### PR TITLE
Suggestion may lead to missing alt attributes

### DIFF
--- a/source/images/index.html.erb.md
+++ b/source/images/index.html.erb.md
@@ -37,7 +37,7 @@ Images must have text alternatives that describe the information or function rep
 
 -   **[Image maps](imagemap.html)**: The text alternative for an image that contains multiple clickable areas should provide an overall context for the set of links. In addition, each individual clickable area should have alternative text that describes the purpose or destination of the link.
 
-For quick overview on deciding which category a specific image fits into, see the [alt Decision Tree](decision-tree.html). The text alternative needs to be determined by the author, depending on the usage, context, and content of an image. For example, the exact type and look of a bird in an image might be less relevant and described only briefly on a website about parks, but may be relevant on a website specifically about birds. Also, there is no need to repeat the information in the text alternative when the page containing the image already describes information provided by the image. For example, the text alternative can simply refer to the description of the type and look of a bird, if that information is already provided on the page.
+For quick overview on deciding which category a specific image fits into, see the [alt Decision Tree](decision-tree.html). The text alternative needs to be determined by the author, depending on the usage, context, and content of an image. For example, the exact type and look of a bird in an image might be less relevant and described only briefly on a website about parks, but may be relevant on a website specifically about birds.
 
 ## Why is this important?
 


### PR DESCRIPTION
This may be me over worrying but I was slightly concerned that saying 'there is no need to repeat the information in the text alternative...' may result in some simply removing the alt attribute in similar cases. The example clarifies this slightly but since there is no code example it could be misunderstood or ignored.

I wonder if this note might be better presented in Tips and Tricks? The first part is sufficient to ensure that author input is required, the second part is supporting info that might even be applicable in other situations.