### PR TITLE
Double check on sentence fragment

### DIFF
--- a/source/images/complex.html.erb.md
+++ b/source/images/complex.html.erb.md
@@ -36,7 +36,7 @@ It is also good practice to refer to and summarize more complex images from the 
 ## Description containing structured information
 {:.ex}
 
-In this example, a bar chart of website visitor statistics has the short description “Bar chart showing monthly and total visitors for the first quarter 2014 for sites 1 to 3”, provided through the `alt` attribute of the image. The long description provides detailed information, including scales, values, relationships and trends that are represented visually. For example, the long description should point out the declining values for site 1, consistent values for site 2, and increasing values for site 3 that are encoded in the bar chart. The [longdesc approach](#providing-a-link-to-the-long-description-via-longdesc) used in the following example is described later in the section.
+In this example, a bar chart of website visitor statistics has the short description “Bar chart showing monthly and total visitors for the first quarter 2014 for sites 1 to 3”, provided through the `alt` attribute of the image. The long description provides detailed information, including scales, values, relationships and trends that are represented visually. For example, the long description can point out the declining values for site 1, consistent values for site 2, and increasing values for site 3 that are encoded in the bar chart. The [longdesc approach](#providing-a-link-to-the-long-description-via-longdesc) used in the following example is described later in the section.
 
 {::nomarkdown}
 <%= sample_start %>


### PR DESCRIPTION
What I'm seeing on the github rendition is"  "The long description provides detailed information, including scales, values, relationships and trends that are represented visually. For example, to point out the declining values for site 1, consistent values for site 2, and increasing values for site 3 that are encoded in the bar chart." The second sentence is a fragment but appears to be corrected in this version.  That's the most important thing.  Meanwhile, suggest changing verb "should" in this version.