### PR TITLE
Permalink z-index causes overlap problems

### DIFF
--- a/source/stylesheets/wai-act.scss
+++ b/source/stylesheets/wai-act.scss
@@ -1086,7 +1086,6 @@ select {
 	font-size: .7em;
 	float:right;
 	margin: 0 0 .5em .5em;
-	z-index: 999;
 	> a {
 		color: #666 !important;
 		border:1px solid #F5F5F5;


### PR DESCRIPTION
This only really occurs when there are two permalinks relatively close together... admittedly not going to happen often, but I noticed it when I was testing. If you open a sharebox immediately above (in the page) another Share link, then the Sharelink overlaps the sharebox. It happens because the z-index on the .permalink container takes priority over the z-index of the contained .sharebox. Not sure why the .permalink needs the z-index; the .sharebox certainly does.