### PR TITLE
Add “(redundant)” to misleading functional image link

### DIFF
--- a/source/images/decision-tree.html.erb.md
+++ b/source/images/decision-tree.html.erb.md
@@ -36,7 +36,7 @@ This decision tree describes how to use the `alt` attribute of the `<img>` eleme
 		-   **… and it’s a graph or complex piece of information.**
 			_Include the information contained in the image elsewhere on the page. See [Complex Images](complex.html)._
 		-   **… and it shows content that is redundant to *real* text nearby.**
-			_Use an empty `alt` attribute. See [Functional Images](functional.html#logo-image-within-link-text)._
+			_Use an empty `alt` attribute. See (redundant) [Functional Images](functional.html#logo-image-within-link-text)._
 	-   {:.no} **No:**
 		-   Continue.
 -   **Is the image purely decorative or not intended for the user?**


### PR DESCRIPTION
Might fix #358.

Currently Published version: https://www.w3.org/WAI/tutorials/images/decision-tree/
Changes from this PR: https://w3c.github.io/wai-tutorials/images/decision-tree/
Diff: http://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FWAI%2Ftutorials%2Fimages%2Fdecision-tree%2F&doc2=https%3A%2F%2Fw3c.github.io%2Fwai-tutorials%2Fimages%2Fdecision-tree%2F

You can comment and/or approve the changes on this page with the diff of the file(s): https://github.com/w3c/wai-tutorials/pull/359/files

Note: Use the blue [+] button (it appears when you hover or tab into a line) to comment on specific lines of the page. You can then use the top-right green button to just comment or request changes. Alternatively you are also able to outright approve the changes there. You can find more information about [Pull Request Reviews in Github’s help](https://help.github.com/articles/reviewing-proposed-changes-in-a-pull-request/). Alternatively you can just leave a comment below with your suggestions.
