### PR TITLE
Menus for Responsive Design

### DIFF
--- a/source/menus/structure.html.erb.md
+++ b/source/menus/structure.html.erb.md
@@ -161,3 +161,7 @@ In the following example the link in the navigation points to the main content o
 {::nomarkdown}
 <%= code_end %>
 {:/nomarkdown}
+
+## Responsive Design
+
+Menu structure should be consistent across screen sizes. Some menu items may be collapsed or even hidden in sub navigation menus, but items that show should appear in the same order. Menus should be accessible by touch and keyboard.


### PR DESCRIPTION
Proposed new subhead "Responsive design" to improve coverage of mobile menus. 

Is there a better location to place this? Also, does this need a code snippet, or snippets? 

Additionally, this resource could be added to the "further resources" section: 
- From "Understanding WCAG 2.0": <https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-consistent-locations.html>