### PR TITLE
Responsive Design Page Regions

### DIFF
--- a/source/page-structure/regions.html.erb.md
+++ b/source/page-structure/regions.html.erb.md
@@ -129,6 +129,10 @@ The [Menus tutorial](/menus/index.html) provides more details on creating menus.
 <%= ref :end %>
 {:/nomarkdown}
 
+## Responsive Design: 
+
+Page structure should be consistent across different screen sizes and orientations. Components may be collapsed or even hidden on smaller screens, but components that show should appear in the same order.
+
 ## Main content
 
 {::nomarkdown}<%= image_tag 'page-structure-main.png', srcset: image_path('page-structure-main.png') + ', ' + image_path('page-structure-main@2x.png') + ' 2x, ' + image_path('page-structure-main@3x.png') + ' 3x', :alt => '', :class => "symbol" %>{:/nomarkdown} Use the HTML5 `<main>` element to identify the main content region of a web page or application.


### PR DESCRIPTION
Proposed inclusion of a point regarding consistent page structure, to increase mobile-friendly coverage. Discussion welcome.

Could also add the following to "Further Resources for Page Structure" at the bottom of the page: 

"From "Mobile Accessibility Mapping": <https://www.w3.org/TR/mobile-accessibility-mapping/#consistent-layout>"