### PR TITLE
Change label id to for attribute

### DIFF
--- a/source/forms/grouping.html.erb.md
+++ b/source/forms/grouping.html.erb.md
@@ -329,7 +329,7 @@ For `select` elements with groups of options, the `optgroup` element can be used
 <form action="#" method="get">
 	<fieldset>
 		<legend>Which course would you like to watch today?</legend>
-		<label id="course">Course:</label>
+		<label for="course">Course:</label>
 		<select name="course" id="course">
 			<option></option>
 			<optgroup label="8.01 Physics I: Classical Mechanics">


### PR DESCRIPTION
I was testing a couple of the examples on this page with a screen reader, and noticed that there wasn't a label being read for the select example. I changed the id attribute to a for attribute to associate the label with the select so that it will be read on screen reader focus.