### PR TITLE
Update decorative.md

### DIFF
--- a/content/images/decorative.md
+++ b/content/images/decorative.md
@@ -34,7 +34,7 @@ support: Developed with support from the <a href="https://www.w3.org/WAI/ACT/">W
 {% include box.html type="start" h="2" title="Overview" class="full" %}
 {:/}
 
-Images which are purely deocrative don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.
+Images which are pure decorative don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.
 
 In these cases, a null (empty) `alt` text should be provided (`alt=""`) so that they can be ignored by assistive technologies, such as screen readers. Text values for these types of images would add audible clutter to screen reader output or could distract users if the topic is different from that in adjacent text. Leaving out the `alt` attribute is also not an option because when it is not provided, some screen readers will announce the file name of the image instead.
 

--- a/content/images/decorative.md
+++ b/content/images/decorative.md
@@ -34,7 +34,7 @@ support: Developed with support from the <a href="https://www.w3.org/WAI/ACT/">W
 {% include box.html type="start" h="2" title="Overview" class="full" %}
 {:/}
 
-Decorative images don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.
+Images which are purely deocrative don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.
 
 In these cases, a null (empty) `alt` text should be provided (`alt=""`) so that they can be ignored by assistive technologies, such as screen readers. Text values for these types of images would add audible clutter to screen reader output or could distract users if the topic is different from that in adjacent text. Leaving out the `alt` attribute is also not an option because when it is not provided, some screen readers will announce the file name of the image instead.
 


### PR DESCRIPTION
From conversation https://github.com/w3c/silver/issues/584 I am suggesting a small edit to distinguish between <q>decorative</q> and <q>pure decoration</q>.

The public facing URL for this page is:  https://www.w3.org/WAI/tutorials/images/decorative/

The page describing this page is:  https://www.w3.org/WAI/tutorials/images/ and the description is:
> **Decorative images:** Provide a null text alternative (`alt=""`) when the only purpose of an image is to add visual decoration to the page, rather than to convey information that is important to understanding the page.