### PR TITLE
Combined patch to update the tutorial in the new design with many of the issues/pull requests for the old design

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem "wai-gems", :path => "_external/data/wai-gems"
+gem "webrick", "~> 1.7"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,7 +63,7 @@
         {% else %}
           Updated
         {% endif %}
-        {{ page.last_modified_at | date: '%d %B %Y' }}
+        {{ page.last_updated | date: '%d %B %Y' }}
         {% if page.first_published %}
         (first published {{ page.first_published }})
         {% endif %}

--- a/content/forms/grouping.md
+++ b/content/forms/grouping.md
@@ -355,7 +355,7 @@ For `select` elements with groups of options, the `optgroup` element can be used
 <form action="#" method="get">
 	<fieldset>
 		<legend>Which course would you like to watch today?</legend>
-		<label id="course">Course:</label>
+		<label for="course">Course:</label>
 		<select name="course" id="course">
 			<option></option>
 			<optgroup label="8.01 Physics I: Classical Mechanics">

--- a/content/forms/instructions.md
+++ b/content/forms/instructions.md
@@ -264,22 +264,7 @@ At the time of writing this tutorial, web browsers usually display the placehold
 {:/}
 
 ~~~ css
-::-webkit-input-placeholder {
-	 color: #767676;
-	 opacity: 1;
-}
-
-:-moz-placeholder { /* Firefox 18- */
-	 color: #767676;
-	 opacity: 1;
-}
-
-::-moz-placeholder {  /* Firefox 19+ */
-	 color: #767676;
-	 opacity: 1;
-}
-
-:-ms-input-placeholder {
+::placeholder {
 	 color: #767676;
 	 opacity: 1;
 }

--- a/content/forms/labels.md
+++ b/content/forms/labels.md
@@ -205,7 +205,7 @@ The `title` attribute can also be used to identify form controls. This approach 
 
 Screen readers and other assistive technology, just as web browsers, hide elements from their users when they are styled using `display: none;` and `visibility: hidden;`.
 
-The common approach used to hide information visually but keep them available to screen reader and other assistive technology users is to use CSS that will keep the information technically visible but practically hidden. For example, presenting the label in a 1-by-1 pixel area with a 1-pixel margin, as demonstrated with the CSS class `visuallyhidden` (**do not confuse** with CSS `visibility: hidden`) below:
+The common approach used to hide information visually but keep them available to screen reader and other assistive technology users is to use CSS that will keep the information technically visible but practically hidden. For example, presenting the label in a 1-by-1 pixel area, as demonstrated with the CSS class `visuallyhidden` (**do not confuse** with CSS `visibility: hidden`) below:
 
 {::nomarkdown}
 {% include box.html type="start" title="Code Snippet" class="example" %}

--- a/content/forms/notifications.md
+++ b/content/forms/notifications.md
@@ -299,7 +299,7 @@ document.getElementById('ex3').addEventListener('submit', function(event){
 		setError(exp, 'Use the format MM/YYYY.');
 	}
 	var usr = document.getElementById('username4');
-	if (taken_usernames.indexOf(usr.value.trim())+1 == false) {
+	if (taken_usernames.includes(usr.value.trim()) == false) {
 		setSuccess(usr);
 	} else {
 		setError(usr, 'Username already taken');
@@ -397,7 +397,7 @@ In the following example, the availability of a username is checked instantly wh
 		}
 		var val = this.value;
 		if (val !== "") {
-			if (taken_usernames.indexOf(val.trim())+1) {
+			if (taken_usernames.includes(val.trim())) {
 				setError(this, '&cross; Sorry, this username is taken.');
 			} else {
 				setSuccess(this, '&check; You can use this username.');
@@ -447,7 +447,7 @@ document.getElementById('username').addEventListener('keyup', function(){
 	}
 	var val = this.value;
 	if (val !== "") {
-		if (taken_usernames.indexOf(val.trim())+1) {
+		if (taken_usernames.includes(val.trim())) {
 			setError(this, '&cross; Sorry, this username is taken.');
 		} else {
 			setSuccess(this, '&check; You can use this username.');
@@ -600,7 +600,7 @@ for (var i = inputs.length - 1; i >= 0; i--) {
 				setError(this, 'Use the format MM/YYYY.');
 			}
 		} else if (this.id == 'username5') {
-			if (taken_usernames.indexOf(this.value.trim())+1 == false) {
+			if (taken_usernames.includes(this.value.trim()) == false) {
 				setSuccess(this);
 			} else {
 				setError(this, 'Username already taken.');

--- a/content/forms/notifications.md
+++ b/content/forms/notifications.md
@@ -574,9 +574,6 @@ In the example below, the user is expected to provide an expiry date. The input 
 		<input type="text" name="expire" id="expire5" value="03.2015" aria-describedby="expDesc3">
 		<span id="expDesc3" aria-live="assertive"></span>
 	</div>
-	<div class="error">
-		<button type="submit">Submit</button>
-	</div>
 </form>
 
 <script>

--- a/content/images/complex.md
+++ b/content/images/complex.md
@@ -201,7 +201,7 @@ No browser indicates the presence of the <code>longdesc</code> attribute visuall
 
 The `longdesc` attribute can contain the URI of a separate web page that provides the long description for an image or a fragment identifier that refers to an element on the same page that provides the long description.
 
-When the `longdesc` attribute contains a URI to refer to another web page with the long description, it is recommended to also apply [Approach 3 (a text link to the long description adjacent to the image)](#a-text-link-to-the-long-description-adjacent-to-the-image). This method is a workaround for web browsers and assistive technologies that don’t fully support the `longdesc` attribute.
+When the `longdesc` attribute contains a URI to refer to another web page with the long description, it is recommended to also apply [Approach 1 (a text link to the long description adjacent to the image)](#a-text-link-to-the-long-description-adjacent-to-the-image). This method is a workaround for web browsers and assistive technologies that don’t fully support the `longdesc` attribute.
 
 {::nomarkdown}
 {% include box.html type="start" title="Code" class="example" %}

--- a/content/images/complex.md
+++ b/content/images/complex.md
@@ -53,7 +53,7 @@ In these cases, a two-part text alternative is required. The first part is the s
 
 There are situations where the composition of an image is important and needs to be provided in the long description. For example, the sequence of colors used and the relative heights of the columns in a bar chart may be relevant information about the structure of the chart, in addition to the actual values and trends that it depicts.
 
-Remember that complex images can be difficult to understand by many people – in particular people with learning disabilities and people with low vision. Long descriptions benefit many people, and it is good practice to make them available to everyone, for example, as part of the main content. It may also be possible to reduce unnecessary complexity in your images and make them easier to understand for everyone.
+Complex images can be difficult to understand by many people – especially those with low vision, learning disabilities, and limited subject-matter experience. Make long descriptions available to everyone to reach a wider audience with your content. For example, show the description as part of the main content. It may also be possible to reduce unnecessary complexity in your images and make them easier to understand for everyone.
 
 It is also good practice to refer to and summarize more complex images from the accompanying text. For example, a reference such as “The following graph shows that visitors were lost in the first quarter, but the numbers recovered in the second quarter” helps to point out the relevant information that the image is intended to present.
 

--- a/content/images/groups.md
+++ b/content/images/groups.md
@@ -115,7 +115,7 @@ alt="The castle lies in ruins, the original tower all that remains in one piece.
 ~~~ html
 <figure role="group" aria-labelledby="fig1">
   <figcaption id="fig1">
-    The castle through the ages: 1423, 1756, and 1966 respectively.
+    The castle through the ages: 1423, 1756, and 1936 respectively.
   </figcaption>
 
 

--- a/content/images/index.md
+++ b/content/images/index.md
@@ -45,7 +45,7 @@ Images must have text alternatives that describe the information or function rep
 
 -   **[Images of text](/tutorials/images/textual/)**: Readable text is sometimes presented within an image. If the image is not a logo, avoid text in images. However, if images of text are used, the text alternative should contain the same words as in the image.
 
--   **[Complex images](/tutorials/images/complex/)** such as graphs and diagrams: To convey data or detailed information, provide a full-text equivalent of the data or information provided in the image as the text alternative.
+-   **[Complex images](/tutorials/images/complex/)** such as graphs and diagrams: To convey data or detailed information, provide a complete text equivalent of the data or information provided in the image as the text alternative.
 
 -   **[Groups of images](/tutorials/images/groups/)**: If multiple images convey a single piece of information, the text alternative for one image should convey the information for the entire group.
 

--- a/content/index.md
+++ b/content/index.md
@@ -16,7 +16,6 @@ metafooter: true
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"
-  - Testy Tester
 contributors:
   - Shawn Lawton Henry: "https://www.w3.org/People/Shawn/"
   - Anna Belle Leiserson

--- a/content/menus/flyout.md
+++ b/content/menus/flyout.md
@@ -27,16 +27,13 @@ contributors:
 support: Developed with support from the <a href="https://www.w3.org/WAI/ACT/">WAI-ACT project</a>, co-funded by the <strong>European Commission <abbr title="Information Society Technologies">IST</abbr> Programme</strong>.
 ---
 
-Use fly-out (or drop-down) menus to provide an overview of a web site’s page hierarchy. It removes the need for multiple page loads provided that users know where to find the information. Application menus are usually implemented this way, too.
+Use fly-out (or drop-down) menus to provide an overview of a web site’s page hierarchy. It removes the need for multiple page loads provided that users know where to find the information. Application menus are implemented similarly, but with additional WAI-ARIA markup.
 
-People with reduced dexterity, such as tremors, often have trouble operating fly-out menus. For some, it might be impossible. Make sure to provide other ways to the submenu items, for example by repeating them on the page of the parent menu item.
+People with reduced dexterity, such as tremors, often have trouble operating fly-out menus. For some, it might be impossible. Make sure to provide other ways to reach the submenu items, for example by repeating them on the page of the parent menu item.
 
 ## Indicate submenus
 
-Indicate menu items with submenus visually and using markup. In the following example, the submenu is indicated visually by an icon and this WAI-ARIA markup:
-
-* `aria-haspopup="true"` declares that a menu item has a submenu.
-* `aria-expanded="false"` declares that the submenu is hidden.
+Indicate navigation menu items with submenus visually and using markup. In the following example, the submenu is indicated visually by an icon. The WAI-ARIA markup `aria-expanded="false"` declares that the submenu navigation is presently hidden, or "collapsed".
 
 {::nomarkdown}
 {% include box.html type="start" title="Code: HTML" class="example" %}
@@ -48,7 +45,7 @@ Indicate menu items with submenus visually and using markup. In the following ex
 				<li><a href="…">Home</a></li>
 				<li><a href="…">Shop</a></li>
 				<li class="has-submenu">
-						<a href="…" aria-haspopup="true" aria-expanded="false">
+						<a href="…" aria-expanded="false">
 							Space Bears
 						</a>
 						<ul>
@@ -96,12 +93,12 @@ In the following example, a delay of one second is added using a timer:
 {% include box.html type="start" title="Example" class="example" %}
 {:/}
 
-<nav role="presentation" aria-label="Main Navigation" id="flyoutnavmousefixed">
+<nav aria-label="(Example) Main" id="flyoutnavmousefixed">
 		<ul>
 				<li><a href="#flyoutnavmousefixed">Home</a></li>
 				<li><a href="#flyoutnavmousefixed">Shop</a></li>
 				<li class="has-submenu">
-						<a href="#flyoutnavmousefixed" aria-haspopup="true" aria-expanded="false">Space Bears</a>
+						<a href="#flyoutnavmousefixed" aria-expanded="false">Space Bears</a>
 						<ul>
 								<li><a href="#flyoutnavmousefixed">Space Bear 6</a></li>
 								<li><a href="#flyoutnavmousefixed">Space Bear 6 Plus</a></li>
@@ -247,12 +244,12 @@ The value of the `href` attribute is ignored but you might still want to link to
 {% include box.html type="start" title="Example" class="example" %}
 {:/}
 
-<nav role="presentation" aria-label="Main Navigation" id="flyoutnavkbfixed">
+<nav aria-label="(Example 2) Main" id="flyoutnavkbfixed">
 		<ul>
 				<li><a href="#flyoutnavkbfixed">Home</a></li>
 				<li><a href="#flyoutnavkbfixed">Shop</a></li>
 				<li class="has-submenu">
-						<a href="#flyoutnavkbfixed" aria-expanded="false" aria-haspopup="true">Space Bears</a>
+						<a href="#flyoutnavkbfixed" aria-expanded="false">Space Bears</a>
 						<ul>
 								<li><a href="#flyoutnavkbfixed">Space Bear 6</a></li>
 								<li><a href="#flyoutnavkbfixed">Space Bear 6 Plus</a></li>
@@ -471,12 +468,12 @@ For situations when the parent menu item needs to carry out a function, such as 
 {% include box.html type="start" title="Example" class="example" %}
 {:/}
 
-<nav role="presentation" aria-label="Main Navigation" id="flyoutnavkbbtn">
+<nav aria-label="(Example 3) Main" id="flyoutnavkbbtn">
 	<ul>
 		<li><a href="#flyoutnavkbbtn">Home</a></li>
 		<li><a href="#flyoutnavkbbtn">Shop</a></li>
 		<li class="has-submenu">
-			<a href="#flyoutnavkbbtn" aria-haspopup="true">Space Bears</a>
+			<a href="#flyoutnavkbbtn">Space Bears</a>
 			<ul>
 				<li><a href="#flyoutnavkbbtn">Space Bear 6</a></li>
 				<li><a href="#flyoutnavkbbtn">Space Bear 6 Plus</a></li>
@@ -660,9 +657,9 @@ Array.prototype.forEach.call(menuItems1, function(el, i){
 		});
 		el.addEventListener("mouseout", function(event){
 				timer1 = setTimeout(function(event){
-						document.querySelector("#flyoutnavkbbtn .has-submenu.open").className = "has-submenu";
 						document.querySelector('#flyoutnavkbbtn .has-submenu.open a').setAttribute('aria-expanded', "false");
 						document.querySelector('#flyoutnavkbbtn .has-submenu.open button').setAttribute('aria-expanded', "false");
+            document.querySelector("#flyoutnavkbbtn .has-submenu.open").className = "has-submenu";
 				}, 1000);
 		});
 		el.querySelector('button').addEventListener("click",  function(event){
@@ -709,7 +706,7 @@ The following code adds a button to every top-level menu item with a submenu. Wh
 {% include box.html type="start" title="Note" class="simple notes" %}
 {:/}
 
-If possible, include the name of the parent menu item in the button label; for example: “show Space Bears submenu”.
+If possible, include the name of the parent menu item in the button’s label; for example: “show Space Bears submenu”.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/content/page-structure/regions.md
+++ b/content/page-structure/regions.md
@@ -48,9 +48,7 @@ Mark up different regions of web pages and applications, so that they can be ide
 {% include box.html type="start" title="Note" class="simple notes" %}
 {:/}
 
-{% include ednote.html note="Clarify description for header and footer." issue="590" repo="w3c/wai-tutorials" status="open" %}
-
-**Note:** If the `<header>` element is used inside `<article>` and `<section>` elements, it is not associated with the whole page, but only with that specific `<article>` or `<section>`.
+**Note:** If the `<header>` element is used inside `<article>` and `<section>` elements, it is not associated to those elements. It does not get the WAI-ARIA `banner` role and does not have special behavior in assistive technologies.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -84,9 +82,7 @@ View a [complete code example](/tutorials/page-structure/example/) for all regio
 {% include box.html type="start" title="Note" class="simple notes" %}
 {:/}
 
-{% include ednote.html note="Clarify description for header and footer." issue="590" repo="w3c/wai-tutorials" status="open" %}
-
-**Note:** If the `<footer>` element is used inside `<article>` and `<section>` elements, it is not identified as the footer for the whole page but only relates to that specific `<article>` or `<section>`.
+**Note:** If the `<footer>` element is used inside `<article>` and `<section>` elements, it is not associated to those elements. It does not get the WAI-ARIA `contentinfo` role and does not have special behavior in assistive technologies.
 
 {::nomarkdown}
 {% include box.html type="end" %}


### PR DESCRIPTION
Steps to add the tutorials to the website in the new layout and with the fixes outlined below fixed:

1. EOWG review and confirm changes in the netlify preview
2. Make changes to this PR if necessary. (It’s not. Changes are either minor editorial, by accessibility experts, or come from AG WG or its sub-groups.)
3. Merge this PR.
4. Merge PR https://github.com/w3c/wai-website/pull/283
5. Merge PR https://github.com/w3c/wai-website-theme/pull/39
5. Merge PR https://github.com/w3c/wai-website-data/pull/81
6. Success

## Included fixes:

- updating metadata https://github.com/w3c/wai-tutorials/commit/4b748074feb0d3ebd5251f3d5e5f03c88cf0e09b
- Fixes w3c/wai-tutorials#628
- Fixes w3c/wai-tutorials#622
- Fixes w3c/wai-tutorials#632 (Typo in image groups)
- Fixes w3c/wai-tutorials#633
- Fixes w3c/wai-tutorials#620
- Fixes w3c/wai-tutorials#590 and fixes w3c/wai-tutorials#606
- Fixes w3c/wai-tutorials#626
- Fixes w3c/wai-tutorials#618
- Fixes w3c/wai-tutorials#629
- Fixes w3c/wai-tutorials#631

---

[Diff for the flyout menus page.](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FWAI%2Ftutorials%2Fmenus%2Fflyout%2F&doc2=https%3A%2F%2Fdeploy-preview-636--wai-tutorials.netlify.app%2Ftutorials%2Fmenus%2Fflyout%2F)