### PR TITLE
QA updates for “new” version of the tutorials

### DIFF
--- a/content/acknowledgements.md
+++ b/content/acknowledgements.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/acknowledgements.md'
 

--- a/content/carousels/animations.md
+++ b/content/carousels/animations.md
@@ -18,8 +18,10 @@ navigation:
 
 wcag_success_criteria:
   - 2.2.2
-first_published: "May 2015"
+
 metafooter: true
+first_published: "May 2015"
+last_updated: 2019-11-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/animations.md
+++ b/content/carousels/animations.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/animations/
 ref: /tutorials/carousels/animations/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/animations.md'
 

--- a/content/carousels/full-code.md
+++ b/content/carousels/full-code.md
@@ -15,8 +15,9 @@ resource:
 navigation:
   previous: /tutorials/carousels/working-example/
 
-first_published: "May 2015"
 metafooter: true
+first_published: "May 2015"
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/full-code.md
+++ b/content/carousels/full-code.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/full-code/
 ref: /tutorials/carousels/full-code/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/full-code.md'
 

--- a/content/carousels/functionality.md
+++ b/content/carousels/functionality.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/functionality/
 ref: /tutorials/carousels/functionality/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/functionality.md'
 

--- a/content/carousels/functionality.md
+++ b/content/carousels/functionality.md
@@ -20,8 +20,10 @@ wcag_success_criteria:
   - 1.3.1
   - 2.1.1
   - 4.1.2
-first_published: "May 2015"
+
 metafooter: true
+first_published: "May 2015"
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/index.md
+++ b/content/carousels/index.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/
 ref: /tutorials/carousels/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/index.md'
 

--- a/content/carousels/index.md
+++ b/content/carousels/index.md
@@ -20,8 +20,10 @@ wcag_success_criteria:
   - 2.1.1
   - 2.2.2
   - 4.1.2
-first_published: "May 2015"
+
 metafooter: true
+first_published: "May 2015"
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/structure.md
+++ b/content/carousels/structure.md
@@ -5,6 +5,7 @@ permalink: /tutorials/carousels/structure/
 ref: /tutorials/carousels/structure/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/structure.md'
 

--- a/content/carousels/structure.md
+++ b/content/carousels/structure.md
@@ -22,8 +22,10 @@ wcag_techniques:
   - G130
   - H42
   - H48
-first_published: "May 2015"
+
 metafooter: true
+first_published: "May 2015"
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/styling.md
+++ b/content/carousels/styling.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/styling/
 ref: /tutorials/carousels/styling/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/styling.md'
 

--- a/content/carousels/styling.md
+++ b/content/carousels/styling.md
@@ -21,8 +21,10 @@ wcag_success_criteria:
 - 1.4.3
 - 2.4.7
 - 2.5.5
-first_published: "May 2015"
+
 metafooter: true
+first_published: "May 2015"
+last_updated: 2018-08-30
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/working-example.md
+++ b/content/carousels/working-example.md
@@ -17,6 +17,7 @@ navigation:
   next: /tutorials/carousels/full-code/
 
 metafooter: true
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/carousels/working-example.md
+++ b/content/carousels/working-example.md
@@ -6,6 +6,7 @@ permalink: /tutorials/carousels/working-example/
 ref: /tutorials/carousels/working-example/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/carousels/working-example.md'
 

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/changelog.md'
 

--- a/content/forms/custom-controls.md
+++ b/content/forms/custom-controls.md
@@ -3,14 +3,13 @@ title: Custom Controls
 permalink: /tutorials/forms/custom-controls/
 ref: /tutorials/forms/custom-controls/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/custom-controls.md'
-metafooter: true
 
 resource:
   ref: /tutorials/forms/
@@ -22,6 +21,7 @@ navigation:
 wcag_success_criteria:
 wcag_techniques:
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/custom-controls.md
+++ b/content/forms/custom-controls.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/custom-controls.md'
 metafooter: true

--- a/content/forms/grouping.md
+++ b/content/forms/grouping.md
@@ -3,7 +3,7 @@ title: Grouping Controls
 permalink: /tutorials/forms/grouping/
 ref: /tutorials/forms/grouping/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
@@ -25,7 +25,9 @@ wcag_techniques:
   - H71
   - ARIA17
   - H85
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/grouping.md
+++ b/content/forms/grouping.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/grouping.md'
 metafooter: true

--- a/content/forms/index.md
+++ b/content/forms/index.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/index.md'
 

--- a/content/forms/index.md
+++ b/content/forms/index.md
@@ -3,7 +3,7 @@ title: "Forms Tutorial"
 permalink: /tutorials/forms/
 ref: /tutorials/forms/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
@@ -23,8 +23,10 @@ wcag_success_criteria:
   - 2.4.6
   - 3.3.2
   - 4.1.2
-first_published: "September 2014"
+
 metafooter: true
+first_published: "September 2014"
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/instructions.md
+++ b/content/forms/instructions.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/instructions.md'
 metafooter: true

--- a/content/forms/instructions.md
+++ b/content/forms/instructions.md
@@ -3,7 +3,7 @@ title: Form Instructions
 permalink: /tutorials/forms/instructions/
 ref: /tutorials/forms/instructions/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
@@ -33,7 +33,9 @@ wcag_techniques:
   - G18
   - ARIA1
   - ARIA9
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/labels.md
+++ b/content/forms/labels.md
@@ -3,14 +3,13 @@ title: Labeling Controls
 permalink: /tutorials/forms/labels/
 ref: /tutorials/forms/labels/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/labels.md'
-metafooter: true
 
 resource:
   ref: /tutorials/forms/
@@ -37,7 +36,9 @@ wcag_techniques:
   - H65
   - ARIA14
   - ARIA16
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/labels.md
+++ b/content/forms/labels.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/labels.md'
 metafooter: true

--- a/content/forms/multi-page.md
+++ b/content/forms/multi-page.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/multi-page.md'
 metafooter: true

--- a/content/forms/multi-page.md
+++ b/content/forms/multi-page.md
@@ -3,14 +3,13 @@ title: Multi-page Forms
 permalink: /tutorials/forms/multi-page/
 ref: /tutorials/forms/multi-page/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/multi-page.md'
-metafooter: true
 
 resource:
   ref: /tutorials/forms/
@@ -31,7 +30,9 @@ wcag_techniques:
   - G198
   - SCR1
   - SCR16
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/notifications.md
+++ b/content/forms/notifications.md
@@ -3,14 +3,13 @@ title: User Notification
 permalink: /tutorials/forms/notifications/
 ref: /tutorials/forms/notifications/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/notifications.md'
-metafooter: true
 
 resource:
   ref: /tutorials/forms/
@@ -28,7 +27,9 @@ wcag_techniques:
   - ARIA18
   - ARIA19
   - ARIA21
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/forms/notifications.md
+++ b/content/forms/notifications.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/notifications.md'
 metafooter: true

--- a/content/forms/validation.md
+++ b/content/forms/validation.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/validation.md'
 metafooter: true

--- a/content/forms/validation.md
+++ b/content/forms/validation.md
@@ -3,14 +3,13 @@ title: Validating Input
 permalink: /tutorials/forms/validation/
 ref: /tutorials/forms/validation/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/forms/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/forms/validation.md'
-metafooter: true
 
 resource:
   ref: /tutorials/forms/
@@ -29,7 +28,9 @@ wcag_techniques:
   - G85
   - G155
   - G168
+
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/complex.md
+++ b/content/images/complex.md
@@ -21,6 +21,7 @@ wcag_techniques:
 - G94
 
 metafooter: true
+last_updated: 2022-01-17
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/complex.md
+++ b/content/images/complex.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/complex.md'
 

--- a/content/images/decision-tree.md
+++ b/content/images/decision-tree.md
@@ -21,6 +21,7 @@ wcag_techniques:
 
 
 metafooter: true
+last_updated: 2017-04-12
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/decision-tree.md
+++ b/content/images/decision-tree.md
@@ -7,6 +7,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/decision-tree.md'
 

--- a/content/images/decorative.md
+++ b/content/images/decorative.md
@@ -21,6 +21,7 @@ wcag_techniques:
 - H67
 
 metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/decorative.md
+++ b/content/images/decorative.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/decorative.md'
 

--- a/content/images/examples/2014-first-qtr.md
+++ b/content/images/examples/2014-first-qtr.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/examples/2014-first-qtr.md'
 metafooter: true

--- a/content/images/examples/2014-first-qtr.md
+++ b/content/images/examples/2014-first-qtr.md
@@ -9,8 +9,9 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/examples/2014-first-qtr.md'
-metafooter: true
 
+metafooter: true
+last_updated: 2015-02-16
 
 wcag_techniques:
 - C22

--- a/content/images/examples/imagemap.md
+++ b/content/images/examples/imagemap.md
@@ -9,8 +9,9 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/examples/imagemap.md'
-metafooter: true
 
+metafooter: true
+last_updated: 2018-08-01
 
 ---
 

--- a/content/images/examples/imagemap.md
+++ b/content/images/examples/imagemap.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/examples/imagemap.md'
 metafooter: true

--- a/content/images/functional.md
+++ b/content/images/functional.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/functional.md'
 

--- a/content/images/functional.md
+++ b/content/images/functional.md
@@ -21,6 +21,7 @@ wcag_techniques:
 - H36
 
 metafooter: true
+last_updated: 2017-04-12
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/groups.md
+++ b/content/images/groups.md
@@ -22,6 +22,7 @@ wcag_techniques:
 - ARIA13
 
 metafooter: true
+last_updated: 2022-02-08
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/groups.md
+++ b/content/images/groups.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/groups.md'
 

--- a/content/images/imagemap.md
+++ b/content/images/imagemap.md
@@ -5,6 +5,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/imagemap.md'
 metafooter: true

--- a/content/images/imagemap.md
+++ b/content/images/imagemap.md
@@ -8,7 +8,6 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/imagemap.md'
-metafooter: true
 
 resource:
   ref: /tutorials/images/imagemap/
@@ -21,6 +20,8 @@ wcag_techniques:
 - H67
 - ARIA13
 
+metafooter: true
+last_updated: 2017-04-12
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/index.md
+++ b/content/images/index.md
@@ -3,7 +3,7 @@ title: "Images Tutorial"
 permalink: /tutorials/images/
 ref: /tutorials/images/
 lang: en
-last_updated: 2019-07-27
+last_updated: 2022-02-08
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:

--- a/content/images/index.md
+++ b/content/images/index.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/index.md'
 metafooter: true

--- a/content/images/informative.md
+++ b/content/images/informative.md
@@ -21,6 +21,7 @@ wcag_techniques:
 - G94
 
 metafooter: true
+last_updated: 2019-06-17
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/informative.md
+++ b/content/images/informative.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/informative.md'
 

--- a/content/images/textual.md
+++ b/content/images/textual.md
@@ -9,7 +9,6 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/textual.md'
-metafooter: true
 
 resource:
   ref: /tutorials/images/
@@ -21,6 +20,8 @@ wcag_techniques:
 - C22
 - G94
 
+metafooter: true
+last_updated: 2017-04-12
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/images/textual.md
+++ b/content/images/textual.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/textual.md'
 metafooter: true

--- a/content/images/tips.md
+++ b/content/images/tips.md
@@ -6,6 +6,7 @@ lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/tips.md'
 metafooter: true

--- a/content/images/tips.md
+++ b/content/images/tips.md
@@ -9,7 +9,7 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/images/tips.md'
-metafooter: true
+
 
 resource:
   ref: /tutorials/images/
@@ -17,6 +17,9 @@ navigation:
   previous: /tutorials/images/decision-tree/
 
 wcag_techniques:
+
+metafooter: true
+last_updated: 2017-04-12
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/index.md
+++ b/content/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorials"
 permalink: /tutorials/
-ref: /tutorials
+ref: /tutorials/
 lang: en
 last_updated: 2019-07-27
 description:
@@ -12,7 +12,6 @@ github:
 
 metafooter: true
 first_published: "September 2014"
-metafooter: true
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/index.md
+++ b/content/index.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/index.md'
 

--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ title: "Tutorials"
 permalink: /tutorials/
 ref: /tutorials/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/images/social.png
 github:
@@ -12,6 +12,7 @@ github:
   path: 'content/index.md'
 
 metafooter: true
+last_updated: 2019-07-27
 first_published: "September 2014"
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"

--- a/content/menus/application-menus-code.md
+++ b/content/menus/application-menus-code.md
@@ -15,8 +15,8 @@ resource:
 navigation:
   previous: /tutorials/menus/application-menus/
 
-
 metafooter: true
+last_updated: 2018-08-02
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/menus/application-menus-code.md
+++ b/content/menus/application-menus-code.md
@@ -6,6 +6,7 @@ permalink: /tutorials/menus/application-menus-code/
 ref: /tutorials/menus/application-menus-code/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/application-menus-code.md'
 

--- a/content/menus/application-menus.md
+++ b/content/menus/application-menus.md
@@ -17,6 +17,7 @@ navigation:
   next: /tutorials/menus/application-menus-code/
 
 metafooter: true
+last_updated: 2018-08-02
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/menus/application-menus.md
+++ b/content/menus/application-menus.md
@@ -6,6 +6,7 @@ permalink: /tutorials/menus/application-menus/
 ref: /tutorials/menus/application-menus/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/application-menus.md'
 

--- a/content/menus/flyout.md
+++ b/content/menus/flyout.md
@@ -6,6 +6,7 @@ permalink: /tutorials/menus/flyout/
 ref: /tutorials/menus/flyout/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/flyout.md'
 

--- a/content/menus/flyout.md
+++ b/content/menus/flyout.md
@@ -19,7 +19,9 @@ navigation:
 wcag_techniques:
   - SCR26
   - H4
+
 metafooter: true
+last_updated: 2022-02-08
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/menus/index.md
+++ b/content/menus/index.md
@@ -5,6 +5,7 @@ permalink: /tutorials/menus/
 ref: /tutorials/menus/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/index.md'
 

--- a/content/menus/index.md
+++ b/content/menus/index.md
@@ -34,10 +34,9 @@ wcag_techniques:
   - G182
   - G183
 
-first_published: "May 2015"
-
-
 metafooter: true
+first_published: "May 2015"
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/menus/structure.md
+++ b/content/menus/structure.md
@@ -21,7 +21,9 @@ wcag_success_criteria:
 wcag_techniques:
   - ARIA6
   - ARIA11
+
 metafooter: true
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/menus/structure.md
+++ b/content/menus/structure.md
@@ -6,6 +6,7 @@ permalink: /tutorials/menus/structure/
 ref: /tutorials/menus/structure/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/structure.md'
 

--- a/content/menus/styling.md
+++ b/content/menus/styling.md
@@ -6,6 +6,7 @@ permalink: /tutorials/menus/styling/
 ref: /tutorials/menus/styling/
 
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/menus/styling.md'
 

--- a/content/menus/styling.md
+++ b/content/menus/styling.md
@@ -23,7 +23,9 @@ wcag_techniques:
   - G128
   - G182
   - G183
+
 metafooter: true
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/content.md
+++ b/content/page-structure/content.md
@@ -10,6 +10,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/content.md
 

--- a/content/page-structure/content.md
+++ b/content/page-structure/content.md
@@ -3,12 +3,7 @@ title: "Content Structure"
 permalink: /tutorials/page-structure/content/
 ref: /tutorials/page-structure/content/
 lang: en
-# translators: # Uncomment (remove #) for translations, one - name line per translator.
-# - name: Translator 1
-# - name: Translator 2
-# contributors:
-# - name: Contributor 1
-# - name: Contributor 2
+
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
@@ -22,6 +17,7 @@ navigation:
   next: /tutorials/page-structure/example/
 
 metafooter: true
+last_updated: 2017-04-13
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/example.md
+++ b/content/page-structure/example.md
@@ -4,12 +4,7 @@ nav_title: Code Example
 permalink: /tutorials/page-structure/example/
 ref: /tutorials/page-structure/example/
 lang: en
-# translators: # Uncomment (remove #) for translations, one - name line per translator.
-# - name: Translator 1
-# - name: Translator 2
-# contributors:
-# - name: Contributor 1
-# - name: Contributor 2
+
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
@@ -23,6 +18,7 @@ navigation:
   previous: /tutorials/page-structure/content/
 
 metafooter: true
+last_updated: 2017-04-20
 editors:
 - Eric Eggert: "https://www.w3.org/People/yatil/"
 - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/example.md
+++ b/content/page-structure/example.md
@@ -11,6 +11,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/example.md
 metafooter: true

--- a/content/page-structure/headings.md
+++ b/content/page-structure/headings.md
@@ -13,7 +13,6 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/headings.md
-metafooter: true
 
 resource:
   ref: /tutorials/page-structure/
@@ -36,6 +35,8 @@ wcag_techniques:
   - ARIA12
   - H42
 
+metafooter: true
+last_updated: 2017-05-04
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/headings.md
+++ b/content/page-structure/headings.md
@@ -10,6 +10,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/headings.md
 metafooter: true

--- a/content/page-structure/index.md
+++ b/content/page-structure/index.md
@@ -3,12 +3,7 @@ title: "Page Structure Tutorial"
 permalink: /tutorials/page-structure/
 ref: /tutorials/page-structure/
 lang: en
-# translators: # Uncomment (remove #) for translations, one - name line per translator.
-# - name: Translator 1
-# - name: Translator 2
-# contributors:
-# - name: Contributor 1
-# - name: Contributor 2
+
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
@@ -19,6 +14,7 @@ navigation:
 
 metafooter: true
 first_published: "April 2017"
+last_updated: 2018-04-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/index.md
+++ b/content/page-structure/index.md
@@ -10,6 +10,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/index.md
 

--- a/content/page-structure/labels.md
+++ b/content/page-structure/labels.md
@@ -3,17 +3,11 @@ title: "Labeling Regions"
 permalink: /tutorials/page-structure/labels/
 ref: /tutorials/page-structure/labels/
 lang: en
-# translators: # Uncomment (remove #) for translations, one - name line per translator.
-# - name: Translator 1
-# - name: Translator 2
-# contributors:
-# - name: Contributor 1
-# - name: Contributor 2
+
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/labels.md
-metafooter: true
 
 resource:
   ref: /tutorials/page-structure/
@@ -29,6 +23,8 @@ wcag_techniques:
   - H69
   - ARIA11
 
+metafooter: true
+last_updated: 2017-04-21
 editors:
 - Eric Eggert: "https://www.w3.org/People/yatil/"
 - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/page-structure/labels.md
+++ b/content/page-structure/labels.md
@@ -10,6 +10,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/labels.md
 metafooter: true

--- a/content/page-structure/regions.md
+++ b/content/page-structure/regions.md
@@ -10,6 +10,7 @@ lang: en
 # - name: Contributor 1
 # - name: Contributor 2
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/regions.md
 metafooter: true

--- a/content/page-structure/regions.md
+++ b/content/page-structure/regions.md
@@ -13,7 +13,6 @@ github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: content/regions.md
-metafooter: true
 
 resource:
   ref: /tutorials/page-structure/
@@ -29,7 +28,8 @@ wcag_success_criteria:
 wcag_techniques:
   - ARIA11
 
-
+metafooter: true
+last_updated: 2022-02-08
 editors:
 - Eric Eggert: "https://www.w3.org/People/yatil/"
 - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/caption-summary.md
+++ b/content/tables/caption-summary.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/caption-summary.md'
 metafooter: true

--- a/content/tables/caption-summary.md
+++ b/content/tables/caption-summary.md
@@ -3,14 +3,13 @@ title: "Caption & Summary"
 permalink: /tutorials/tables/caption-summary/
 ref: /tutorials/tables/caption-summary/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/caption-summary.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
@@ -22,6 +21,8 @@ wcag_techniques:
 - H73
 - H39
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/index.md
+++ b/content/tables/index.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/index.md'
 metafooter: true

--- a/content/tables/index.md
+++ b/content/tables/index.md
@@ -3,17 +3,18 @@ title: "Tables Tutorial"
 permalink: /tutorials/tables/
 ref: /tutorials/tables/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/index.md'
-metafooter: true
 
 resource_title: Tables Tutorial
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/irregular.md
+++ b/content/tables/irregular.md
@@ -8,6 +8,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/irregular.md'
 metafooter: true

--- a/content/tables/irregular.md
+++ b/content/tables/irregular.md
@@ -4,14 +4,13 @@ nav_title: Irregular Headers
 permalink: /tutorials/tables/irregular/
 ref: /tutorials/tables/irregular/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/irregular.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
@@ -22,6 +21,8 @@ navigation:
 wcag_techniques:
 - H63
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/multi-level.md
+++ b/content/tables/multi-level.md
@@ -8,6 +8,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/multi-level.md'
 metafooter: true

--- a/content/tables/multi-level.md
+++ b/content/tables/multi-level.md
@@ -4,14 +4,13 @@ nav_title: Multi-Level Headers
 permalink: /tutorials/tables/multi-level/
 ref: /tutorials/tables/multi-level/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/multi-level.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
@@ -22,6 +21,8 @@ navigation:
 wcag_techniques:
 - H63
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/one-header.md
+++ b/content/tables/one-header.md
@@ -4,14 +4,13 @@ nav_title: One Header
 permalink: /tutorials/tables/one-header/
 ref: /tutorials/tables/one-header/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/one-header.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
@@ -23,6 +22,8 @@ wcag_techniques:
 - H51
 - H63
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/one-header.md
+++ b/content/tables/one-header.md
@@ -8,6 +8,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/one-header.md'
 metafooter: true

--- a/content/tables/tips.md
+++ b/content/tables/tips.md
@@ -3,21 +3,21 @@ title: "Tips and Tricks"
 permalink: /tutorials/tables/tips/
 ref: /tutorials/tables/tips/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/tips.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
 navigation:
   previous: /tutorials/tables/caption-summary/
 
-
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/tips.md
+++ b/content/tables/tips.md
@@ -7,6 +7,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/tips.md'
 metafooter: true

--- a/content/tables/two-headers.md
+++ b/content/tables/two-headers.md
@@ -4,14 +4,13 @@ nav_title: Two Header
 permalink: /tutorials/tables/two-headers/
 ref: /tutorials/tables/two-headers/
 lang: en
-last_updated: 2019-07-27
+
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
   branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/two-headers.md'
-metafooter: true
 
 resource:
   ref: /tutorials/tables/
@@ -23,6 +22,8 @@ wcag_techniques:
 - H51
 - H63
 
+metafooter: true
+last_updated: 2019-07-27
 editors:
   - Eric Eggert: "https://www.w3.org/People/yatil/"
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"

--- a/content/tables/two-headers.md
+++ b/content/tables/two-headers.md
@@ -8,6 +8,7 @@ last_updated: 2019-07-27
 description:
 image: /content-images/wai-tutorials/tables/social.png
 github:
+  branch: 'master-2.0'
   repository: w3c/wai-tutorials
   path: 'content/tables/two-headers.md'
 metafooter: true


### PR DESCRIPTION
**Before merging this Pull Request, also merge this Pull Request:**

- https://github.com/w3c/wai-website-theme/pull/40 which fixes https://github.com/w3c/wai-tutorials/issues/643

**This patch fixes:**

- https://github.com/w3c/wai-tutorials/pull/646/commits/df07bc48da2c32cc748efbb03f3bd29d6d33b216 fixes https://github.com/w3c/wai-tutorials/issues/641
- https://github.com/w3c/wai-tutorials/pull/646/commits/4720f94f95d2f882d1d490858689fff5bc6e43a5 fixes https://github.com/w3c/wai-tutorials/issues/642 and fixes https://github.com/w3c/wai-tutorials/issues/645
- Many updates for footer data to display the last updated date, which fixes https://github.com/w3c/wai-tutorials/issues/644