### PR TITLE
Typo in navigation.yaml

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -165,7 +165,7 @@
       pages:
       - name: Labeling Controls
         url: "/tutorials/forms/labels/"
-      - name: Gruping Controls
+      - name: Grouping Controls
         url: "/tutorials/forms/grouping/"
       - name: Form Instructions
         url: "/tutorials/forms/instructions/"


### PR DESCRIPTION
Fixed typo for Grouping Controls