### PR TITLE
Add 2.4.1 Bypass Blocks

### DIFF
--- a/content/menus/index.md
+++ b/content/menus/index.md
@@ -15,6 +15,7 @@ navigation:
   next: /tutorials/menus/structure/
 
 wcag_success_criteria:
+  - 2.4.1
   - 2.4.3
   - 2.4.5
   - 2.4.7


### PR DESCRIPTION
Add 2.4.1 Bypass Blocks to list of WCAG Success Criteria relevant to menus.
- In particular, a menu with drop-down sub-items must provide a means for keyboard user to skip over those (to the next main item).