### PR TITLE
Fix link to start with Carousel tutorial

### DIFF
--- a/content/carousels/index.md
+++ b/content/carousels/index.md
@@ -13,7 +13,7 @@ github:
 resource:
   ref: /tutorials/
 navigation:
-  next: /tutorials/carousels/
+  next: /tutorials/carousels/structure
 
 wcag_success_criteria:
   - 1.3.1

--- a/content/carousels/index.md
+++ b/content/carousels/index.md
@@ -13,7 +13,7 @@ github:
 resource:
   ref: /tutorials/
 navigation:
-  next: /tutorials/carousels/structure
+  next: /tutorials/carousels/structure/
 
 wcag_success_criteria:
   - 1.3.1


### PR DESCRIPTION
The "Next" link on the [Carousels Tutorial](https://www.w3.org/WAI/tutorials/carousels) points to the page itself