### PR TITLE
Remove old IE workaround

### DIFF
--- a/content/forms/instructions.md
+++ b/content/forms/instructions.md
@@ -160,24 +160,12 @@ One approach is to use the WAI-ARIA `aria-labelledby` attribute to associate ins
 {:/}
 
 ~~~ html
-<label id="expLabel" for="expire" tabindex="-1">Expiration date:</label>
+<label id="expLabel" for="expire">Expiration date:</label>
 <span>
 	<input type="text" name="expire" id="expire" aria-labelledby="expLabel expDesc">
-	<span id="expDesc" tabindex="-1">MM/YYYY</span>
+	<span id="expDesc">MM/YYYY</span>
 </span>
 ~~~
-
-{::nomarkdown}
-{% include box.html type="end" %}
-{:/}
-
-{::nomarkdown}
-{% include box.html type="start" title="Note" class="simple notes" %}
-{:/}
-
-{% include ednote.html note="Remove this note" %}
-
-**Note:** At the time of writing those tutorials, it is necessary to add `tabindex="-1"` to elements that are referenced by `aria-labelledby` or `aria-describedby` if those attributes point to _two or more_ elements to make this technique work in Internet Explorer.
 
 {::nomarkdown}
 {% include box.html type="end" %}


### PR DESCRIPTION
I guess this wasn’t needed since IE9?