### PR TITLE
Fixing Next button in groups

### DIFF
--- a/content/images/imagemap.md
+++ b/content/images/imagemap.md
@@ -1,6 +1,7 @@
 ---
 title: "Image Maps"
 permalink: /tutorials/images/imagemap/
+ref: /tutorials/images/imagemap/
 lang: en
 description:
 image: /content-images/wai-tutorials/images/social.png


### PR DESCRIPTION
Added "ref" meta data to imagemap file to enable next button to work on groups page