### PR TITLE
Use rowgroup in multi-level table headings example 2

### DIFF
--- a/content/tables/multi-level.md
+++ b/content/tables/multi-level.md
@@ -180,7 +180,7 @@ In this example, table headers are used as subheadings to describe what the next
 </thead>
 <tbody>
     <tr>
-        <th id="par" class="span" colspan="5" scope="colgroup">
+        <th id="par" class="span" colspan="5" scope="rowgroup">
             Paris
         </th>
     </tr>
@@ -236,7 +236,7 @@ In this example, table headers are used as subheadings to describe what the next
         </td>
     </tr>
     <tr>
-        <th id="rome" class="span" colspan="5" scope="colgroup">
+        <th id="rome" class="span" colspan="5" scope="rowgroup">
             Rome
         </th>
     </tr>

--- a/content/tables/multi-level.md
+++ b/content/tables/multi-level.md
@@ -235,6 +235,8 @@ In this example, table headers are used as subheadings to describe what the next
             40
         </td>
     </tr>
+</tbody>
+<tbody>
     <tr>
         <th id="rome" class="span" colspan="5" scope="rowgroup">
             Rome


### PR DESCRIPTION
The heading is for a group of rows, so we should use `scope=rowgroup`. We can use multiple `tbody` elements to reinforce this grouping.