### PR TITLE
[Ready to Review] German - An alt Decision Tree

### DIFF
--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -1,6 +1,6 @@
 ---
-title: "Ein alt Entscheidungsbaum"
-title_html: "Ein <code>alt</code> Entscheidungsbaum"
+title: "Ein alt-Entscheidungsbaum"
+title_html: "Ein <code>alt</code>-Entscheidungsbaum"
 lang: de
 last_updated: 2023-12-22
 
@@ -41,7 +41,7 @@ support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbei
 {% include box.html type="start" h="2" title="Überblick" class="full" %}
 {:/}
 
-Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `img`-Elements in verschiedenen Situationen verwendet. Für manche Arten von Bildern gibt es Alternativen, etwa CSS-Hintergrundbilder für dekorative Bilder oder Webfonts anstelle von Bildern von Text.
+Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `<img>`-Elements in verschiedenen Situationen verwendet. Für manche Arten von Bildern gibt es Alternativen, etwa CSS-Hintergrundbilder für dekorative Bilder oder Webfonts anstelle von Bildern von Text.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -54,7 +54,7 @@ Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `img`-Elemen
     -   **… und der Text wird nur für visuelle Effekte dargestellt.**
       _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
     -   **… und der Text hat eine bestimmte Funktion, beispielsweise handelt es sich um ein Icon.**
-      _Nutzen sie das `alt`-Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
+      _Nutzen Sie das `alt`-Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
     -   **… und der Text im Bild ist ansonsten nicht vorhanden.** _Nutzen Sie das `alt`-Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
@@ -63,7 +63,7 @@ Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `img`-Elemen
     - _Nutzen Sie das `alt`-Attribut, um das Ziel des Links oder die Aktion zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
-- **Trägt das Bild zur Bedeutung der aktuellen Seite oder des aktuellen Kontexts bei?**
+- **Trägt das Bild zur Bedeutung der aktuellen Seite oder des aktuellen Zusammenhangs bei?**
   - {:.yes} **Ja:**
     - **… und es ist eine einfache Grafik oder ein Foto.**
       _Nutzen Sie eine kurze Beschreibung des Bildes im `alt`-Attribut, die diese Bedeutung vermittelt. Siehe [Informative Bilder](/tutorials/images/informative/)._
@@ -73,11 +73,11 @@ Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `img`-Elemen
       _Nutzen Sie ein leeres `alt`-Attribut. Siehe (redundante) [Funktionale Bilder](/tutorials/images/functional/#logo-image-within-link-text)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
-- **Ist das Bild rein dekorativ oder nicht für Nutzerinnen und Nutzer gedacht?**
+- **Ist das Bild rein dekorativ oder nicht für Nutzende gedacht?**
   - {:.yes} **Ja:**
     - _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
 - **Ist der Zweck des Bildes nicht in der obigen Auflistung enthalten oder ist es unklar, welcher `alt`-Text zu verwenden ist?**
-  - {:.yes} Dieser Entscheidungsbaum deckt **nicht alle** Fälle ab. Für detailierte Informationen über die Bereitstellung von Textalternativen, sehen Sie sich die [Seite zu Bildkonzepten](/tutorials/images/) an.
+  - {:.yes} Dieser Entscheidungsbaum deckt **nicht alle** Fälle ab. Für detailierte Informationen über die Bereitstellung von Textalternativen, beachten Sie die [Seite zu Bildkonzepten](/tutorials/images/).
 {:.decision-tree}

--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -29,7 +29,7 @@ update_editors:
   - Brian Elton
 contributors:
   - siehe <a href="/WAI/tutorials/acknowledgements/">Danksagung</a>
-support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbeit (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Entwickelt mit der Unterstützung vom <a href="https://www.w3.org/WAI/ACT/">WAI-ACT Projekt</a>, kofinanziert vom <strong><abbr title="Information Society Technologies">IST</abbr> Programm der Europäischen Kommission</strong>.
+support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbeit (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Entwickelt mit der Unterstützung vom <a href="https://www.w3.org/WAI/ACT/">WAI-ACT-Projekt</a>, kofinanziert vom <strong><abbr title="Information Society Technologies">IST</abbr>-Programm der Europäischen Kommission</strong>.
 
 ---
 
@@ -37,7 +37,7 @@ support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbei
 {% include box.html type="start" h="2" title="Überblick" class="full" %}
 {:/}
 
-Dieser Entscheidungsbaum beschreibt wie man das `alt` Attribut des `img` Elements in verschiedenen Situationen verwendet. Für manche Arten von Bildern gibt es Alternativen, etwa CSS-Hintergrundbilder für dekorative Bilder oder Web Fonts anstelle von Bildern von Text.
+Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `img`-Elements in verschiedenen Situationen verwendet. Für manche Arten von Bildern gibt es Alternativen, etwa CSS-Hintergrundbilder für dekorative Bilder oder Webfonts anstelle von Bildern von Text.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -46,34 +46,34 @@ Dieser Entscheidungsbaum beschreibt wie man das `alt` Attribut des `img` Element
 - **Enthält das Bild Text?**
   - {:.yes} **Ja:**
     -   **… und der Text ist auch als *richtiger* Text in der Nähe vorhanden.**
-      _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+      _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
     -   **… und der Text wird nur für visuelle Effekte dargestellt.**
-      _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+      _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
     -   **… und der Text hat eine bestimmte Funktion, beispielsweise handelt es sich um ein Icon.**
-      _Nutzen sie das `alt` Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
-    -   **… und der Text im Bild ist ansonsten nicht vorhanden.** _Nutzen Sie das `alt` Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
+      _Nutzen sie das `alt`-Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
+    -   **… und der Text im Bild ist ansonsten nicht vorhanden.** _Nutzen Sie das `alt`-Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
 - **Wird das Bild in einem Link oder Button verwendet und wäre es schwer oder unmöglich zu verstehen, was der Link oder Button tut, wenn das Bild fehlen würde?**
   - {:.yes} **Ja:**
-    - _Nutzen Sie das `alt` Attribut, um das Ziel des Links oder die Aktion zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
+    - _Nutzen Sie das `alt`-Attribut, um das Ziel des Links oder die Aktion zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
 - **Trägt das Bild zur Bedeutung der aktuellen Seite oder des aktuellen Kontexts bei?**
   - {:.yes} **Ja:**
     - **… und es ist eine einfache Grafik oder ein Foto.**
-      _Nutzen Sie eine kurze Beschreibung des Bildes im `alt` Attribut, die diese Bedeutung vermittelt. Siehe [Informative Bilder](/tutorials/images/informative/)._
+      _Nutzen Sie eine kurze Beschreibung des Bildes im `alt`-Attribut, die diese Bedeutung vermittelt. Siehe [Informative Bilder](/tutorials/images/informative/)._
     - **… und es ist ein Graph oder komplexe Information.**
       _Vermitteln Sie die Information aus dem Bild auch an anderer Stelle auf der Seite. Siehe [Komplexe Bilder](/tutorials/images/complex/)._
     - **… und es zeigt Inhalt, der in *richtigem* Text in der Nähe enthalten ist.**
-      _Nutzen Sie ein leeres `alt` Attribut. Siehe (redundante) [Funktionale Bilder](/tutorials/images/functional/#logo-image-within-link-text)._
+      _Nutzen Sie ein leeres `alt`-Attribut. Siehe (redundante) [Funktionale Bilder](/tutorials/images/functional/#logo-image-within-link-text)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
-- **Ist das Bild rein dekorativ oder nicht für Nutzer:innen gedacht?**
+- **Ist das Bild rein dekorativ oder nicht für Nutzerinnen und Nutzer gedacht?**
   - {:.yes} **Ja:**
-    - _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+    - _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
-- **Ist der Zweck des Bildes nicht in der obigen Auflistung enthalten oder ist es unklar, welcher `alt` Text zu verwenden ist?**
+- **Ist der Zweck des Bildes nicht in der obigen Auflistung enthalten oder ist es unklar, welcher `alt`-Text zu verwenden ist?**
   - {:.yes} Dieser Entscheidungsbaum deckt **nicht alle** Fälle ab. Für detailierte Informationen über die Bereitstellung von Textalternativen, sehen Sie sich die [Seite zu Bildkonzepten](/tutorials/images/) an.
 {:.decision-tree}

--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -1,0 +1,79 @@
+---
+title: "Ein alt Entscheidungsbaum"
+title_html: "Ein <code>alt</code> Entscheidungsbaum"
+lang: de
+last_updated: 2023-12-22
+
+translators:
+  - name: "Alexej Rotar"
+
+github:
+  branch: 'master-2.0'
+  repository: w3c/wai-tutorials
+  path: 'content/images/decision-tree.de.md'
+
+resource:
+  ref: /tutorials/images/
+navigation:
+  previous: /tutorials/images/imagemap/
+  next: /tutorials/images/tips/
+
+permalink: /tutorials/images/decision-tree/de
+ref: /tutorials/images/decision-tree/
+
+metafooter: true
+editors:
+  - Eric Eggert: "https://www.w3.org/People/yatil/"
+  - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"
+update_editors:
+  - Brian Elton
+contributors:
+  - siehe <a href="/WAI/tutorials/acknowledgements/">Danksagung</a>
+support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbeit (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Entwickelt mit der Unterstützung vom <a href="https://www.w3.org/WAI/ACT/">WAI-ACT Projekt</a>, kofinanziert vom <strong><abbr title="Information Society Technologies">IST</abbr> Programm der Europäischen Kommission</strong>.
+
+---
+
+{::nomarkdown}
+{% include box.html type="start" h="2" title="Überblick" class="full" %}
+{:/}
+
+Dieser Entscheidungsbaum beschreibt wie man das `alt` Attribut des `img` Elements in verschiedenen Situationen verwendet. Für manche Arten von Bildern gibt es Alternativen, etwa CSS-Hintergrundbilder für dekorative Bilder oder Web Fonts anstelle von Bildern von Text.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
+- **Enthält das Bild Text?**
+  - {:.yes} **Ja:**
+    -   **… und der Text ist auch als *richtiger* Text in der Nähe vorhanden.**
+      _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+    -   **… und der Text wird nur für visuelle Effekte dargestellt.**
+      _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+    -   **… und der Text hat eine bestimmte Funktion, beispielsweise handelt es sich um ein Icon.**
+      _Nutzen sie das `alt` Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
+    -   **… und der Text im Bild ist ansonsten nicht vorhanden.** _Nutzen Sie das `alt` Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
+  - {:.no} **Nein:**
+    - Fahren Sie fort.
+- **Wird das Bild in einem Link oder Button verwendet und wäre es schwer oder unmöglich zu verstehen, was der Link oder Button tut, wenn das Bild fehlen würde?**
+  - {:.yes} **Ja:**
+    - _Nutzen Sie das `alt` Attribut, um das Ziel des Links oder die Aktion zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
+  - {:.no} **Nein:**
+    - Fahren Sie fort.
+- **Trägt das Bild zur Bedeutung der aktuellen Seite oder des aktuellen Kontexts bei?**
+  - {:.yes} **Ja:**
+    - **… und es ist eine einfache Grafik oder ein Foto.**
+      _Nutzen Sie eine kurze Beschreibung des Bildes im `alt` Attribut, die diese Bedeutung vermittelt. Siehe [Informative Bilder](/tutorials/images/informative/)._
+    - **… und es ist ein Graph oder komplexe Information.**
+      _Vermitteln Sie die Information aus dem Bild auch an anderer Stelle auf der Seite. Siehe [Komplexe Bilder](/tutorials/images/complex/)._
+    - **… und es zeigt Inhalt, der in *richtigem* Text in der Nähe enthalten ist.**
+      _Nutzen Sie ein leeres `alt` Attribut. Siehe (redundante) [Funktionale Bilder](/tutorials/images/functional/#logo-image-within-link-text)._
+  - {:.no} **Nein:**
+    - Fahren Sie fort.
+- **Ist das Bild rein dekorativ oder nicht für Nutzer:innen gedacht?**
+  - {:.yes} **Ja:**
+    - _Nutzen Sie ein leeres `alt` Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
+  - {:.no} **Nein:**
+    - Fahren Sie fort.
+- **Ist der Zweck des Bildes nicht in der obigen Auflistung enthalten oder ist es unklar, welcher `alt` Text zu verwenden ist?**
+  - {:.yes} Dieser Entscheidungsbaum deckt **nicht alle** Fälle ab. Für detailierte Informationen über die Bereitstellung von Textalternativen, sehen Sie sich die [Seite zu Bildkonzepten](/tutorials/images/) an.
+{:.decision-tree}

--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -6,6 +6,10 @@ last_updated: 2023-12-22
 
 translators:
   - name: "Alexej Rotar"
+contributors:
+  - name: "Jens Oliver Meiert"
+    link: "https://meiert.com/de/biography/"
+  - name: "Doro Hinrichs"
 
 github:
   branch: 'master-2.0'
@@ -27,7 +31,7 @@ editors:
   - Shadi Abou-Zahra: "https://www.w3.org/People/shadi/"
 update_editors:
   - Brian Elton
-contributors:
+contributing_participants:
   - siehe <a href="/WAI/tutorials/acknowledgements/">Danksagung</a>
 support: Entwickelt von der Arbeitsgruppe für Bildung und Öffentlichkeitsarbeit (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Entwickelt mit der Unterstützung vom <a href="https://www.w3.org/WAI/ACT/">WAI-ACT-Projekt</a>, kofinanziert vom <strong><abbr title="Information Society Technologies">IST</abbr>-Programm der Europäischen Kommission</strong>.
 

--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -2,7 +2,7 @@
 title: "Ein alt-Entscheidungsbaum"
 title_html: "Ein <code>alt</code>-Entscheidungsbaum"
 lang: de
-last_updated: 2023-12-22
+last_updated: 2024-04-08
 
 translators:
   - name: "Alexej Rotar"

--- a/content/images/decision-tree.de.md
+++ b/content/images/decision-tree.de.md
@@ -55,7 +55,7 @@ Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `<img>`-Elem
       _Nutzen Sie ein leeres `alt`-Attribut. Siehe [Dekorative Bilder](/tutorials/images/decorative/)._
     -   **… und der Text hat eine bestimmte Funktion, beispielsweise handelt es sich um ein Icon.**
       _Nutzen Sie das `alt`-Attribut, um die Funktion des Bildes zu kommunizieren. Siehe [Funktionale Bilder](/tutorials/images/functional/)._
-    -   **… und der Text im Bild ist ansonsten nicht vorhanden.** _Nutzen Sie das `alt`-Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
+    -   **… und der Text im Bild kommt sonst nirgends vor.** _Nutzen Sie das `alt`-Attribut, um den Text aus dem Bild zu wiederholen. Siehe [Bilder von Text](/tutorials/images/textual/#styled-text-decorative-effect)._
   - {:.no} **Nein:**
     - Fahren Sie fort.
 - **Wird das Bild in einem Link oder Button verwendet und wäre es schwer oder unmöglich zu verstehen, was der Link oder Button tut, wenn das Bild fehlen würde?**
@@ -67,7 +67,7 @@ Dieser Entscheidungsbaum beschreibt, wie man das `alt`-Attribut des `<img>`-Elem
   - {:.yes} **Ja:**
     - **… und es ist eine einfache Grafik oder ein Foto.**
       _Nutzen Sie eine kurze Beschreibung des Bildes im `alt`-Attribut, die diese Bedeutung vermittelt. Siehe [Informative Bilder](/tutorials/images/informative/)._
-    - **… und es ist ein Graph oder komplexe Information.**
+    - **… und es ist ein Graph oder stellt komplexe Informationen dar.**
       _Vermitteln Sie die Information aus dem Bild auch an anderer Stelle auf der Seite. Siehe [Komplexe Bilder](/tutorials/images/complex/)._
     - **… und es zeigt Inhalt, der in *richtigem* Text in der Nähe enthalten ist.**
       _Nutzen Sie ein leeres `alt`-Attribut. Siehe (redundante) [Funktionale Bilder](/tutorials/images/functional/#logo-image-within-link-text)._


### PR DESCRIPTION
⚠️ Another PR `master-2.0` > `publication` will be needed to publish this.

For the frontmatter, I added translations in [a PR for WAI website data](https://github.com/w3c/wai-website-data/pull/119).

Some open questions:
1. Sometimes english words make more sense (or are more common) even in german. For instance, I did not translate the word 'icon'. Should I wrap such words/terms in `span`s with a according `lang` attribute?
2. In german, most words referring to persons are gendered. E.g. the word 'user' is translated to either 'Nutzer' or 'Nutzerin'. The same goes for the articles, 'der' or 'die', respectively. In cases where the gender is unknown or irrelevant (as is mostly the case here), people used to use the male version as neutral. But now there is an ongoing effort to introduce gender-neutral forms to make the language more inclusive. They sort of combine both forms, such as 'Nutzer*in', 'Nutzer:in', 'Nutzer_in', or 'NutzerIn'. I think, a more inclusive language is important and so I used the form 'Nutzer:in' (for no particular reason). Not everyone might agree though, so a discussion about the proper translation of gendered words might be useful for consistency across the translations.

Resolves https://github.com/w3c/wai-translations/issues/159