### PR TITLE
[Temporary fix] Display Japanese contributor

### DIFF
--- a/content/images/decision-tree.ja.md
+++ b/content/images/decision-tree.ja.md
@@ -9,9 +9,7 @@ last_updated: 2024-02-23 # Put the date of this translation YYYY-MM-DD (with mon
 
 translators:
   - name: "Hiroya UGA"
-
-contributors:
-  - name: "Naoki Nakamura"
+  - name: "寄稿者 Naoki Nakamura"
 
 github:
   branch: "master-2.0"


### PR DESCRIPTION
Temporary fix until https://github.com/w3c/wai-tutorials/issues/756 is resolved.

Preview: https://deploy-preview-757--wai-tutorials2.netlify.app/tutorials/images/decision-tree/ja

What it does:
- Use the `translators` variable to acknowledge the work of the contributor.

What needs to be properly fixed later:
- Being able to use the usual `contributors` variable to list translation contributors.
- Not repeating "Contributor" (寄稿者) in the disclaimer box.