### PR TITLE
Alt Decision Tree - Update link text to Images Tutorials

### DIFF
--- a/content/images/decision-tree.md
+++ b/content/images/decision-tree.md
@@ -87,5 +87,5 @@ This decision tree describes how to use the `alt` attribute of the `<img>` eleme
   - {:.no} **No:**
     - Continue.
 - **Is the image’s use not listed above or it’s unclear what `alt` text to provide?**
-  - {:.yes} This decision tree **does not** cover all cases. For detailed information on the provision of text alternatives refer to the [Image Concepts Page](/tutorials/images/).
+  - {:.yes} This decision tree **does not** cover all cases. For detailed information on the provision of text alternatives refer to the [[Images Tutorials]](/tutorials/images/).
 {:.decision-tree}

--- a/content/images/index.md
+++ b/content/images/index.md
@@ -14,6 +14,8 @@ metafooter: true
 
 resource:
   ref: /tutorials/
+  title: "Images Tutorials"
+
 navigation:
   next: /tutorials/images/informative/
 


### PR DESCRIPTION
- "Image Concepts Page" > "Images Tutorials"
- Use double-brackets to automatically display the current title of the target page.

Direct link to preview: https://deploy-preview-774--wai-tutorials2.netlify.app/tutorials/images/decision-tree/

Resolves https://github.com/w3c/wai-tutorials/issues/753