### PR TITLE
Remove section on redundant use of ARIA roles on HTML5

### DIFF
--- a/content/page-structure/regions.md
+++ b/content/page-structure/regions.md
@@ -183,34 +183,6 @@ The [Menus tutorial](/tutorials/menus/) provides more details on creating menus.
 {% include box.html type="end" %}
 {:/}
 
-{% include ednote.html note="Remove or drastically simplify the next two sections." status="proposed" %}
-
-## Page Regions in HTML5 Using WAI-ARIA
-{:#accessupport}
-
-Most current web browsers support the above HTML5 elements and convey the information to assistive technology through the accessibility APIs. However, to maximize compatibility with web browsers and assistive technologies that support WAI-ARIA but do not yet support HTML5, it is currently advisable to use both the HTML5 elements and the corresponding WAI-ARIA roles.
-
-{::nomarkdown}
-{% include box.html type="start" title="Examples in HTML5" class="example" %}
-{:/}
-
-~~~html
-<header role="banner">…</header>
-<main role="main">…</main>
-<nav role="navigation">…</nav>
-<footer role="contentinfo">…</footer>
-~~~
-
-{::nomarkdown}
-{% include box.html type="end" %}
-{:/}
-
-{% include ednote.html note="Figure out how to display reference links now that the sidebar is not available anymore." %}
-
-Explore other WAI-ARIA resources:
-
-* [WAI-ARIA Overview](https://www.w3.org/WAI/intro/aria)
-* [Notes on Using ARIA in HTML](https://www.w3.org/TR/aria-in-html/)
 
 ## Page Regions in HTML4 Using WAI-ARIA
 {:#accessupport-html4}
@@ -231,3 +203,8 @@ If HTML5 cannot be used or if an HTML4 page is retrofitted to improve accessibil
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
+
+Explore other WAI-ARIA resources:
+
+* [WAI-ARIA Overview](https://www.w3.org/WAI/intro/aria)
+* [Notes on Using ARIA in HTML](https://www.w3.org/TR/html-aria/)


### PR DESCRIPTION
Removing section describing redundant use of roles on HTML5 elements on [Regions](https://www.w3.org/WAI/tutorials/page-structure/regions/#accessupport) page.

Based on w3c/wai-website#598 