### PR TITLE
Display H2 to H4 in table of contents in certain pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ exclude:
 
 # Build settings
 markdown: kramdown
-kramwdown:
+kramdown:
   toc_levels: 2..3
   input: GFM
   syntax_highlighter: rouge

--- a/content/forms/instructions.md
+++ b/content/forms/instructions.md
@@ -18,7 +18,6 @@ navigation:
   previous: /tutorials/forms/grouping/
   next: /tutorials/forms/validation/
 
-
 wcag_success_criteria:
   - 1.3.1
   - 2.4.6
@@ -56,6 +55,7 @@ Provide instructions to help users understand how to complete the form and use i
 {% include box.html type="end" %}
 {:/}
 
+{::options toc_levels="2,3,4" /}
 {% include_cached toc.html %}
 
 **Important:** Screen readers often switch to “Forms Mode” when they are processing content within a `<form>` element. In this mode they usually only read aloud form elements such as `<input>`, `<select>`, `<textarea>`, `<legend>`, and `<label>`. It is critical to include form instructions in ways that can be read aloud. This will be explained further below.

--- a/content/forms/labels.md
+++ b/content/forms/labels.md
@@ -59,6 +59,7 @@ Provide labels to identify all form controls, including text fields, checkboxes,
 {% include box.html type="end" %}
 {:/}
 
+{::options toc_levels="2,3,4" /}
 {% include_cached toc.html %}
 
 Labels need to describe the purpose of the form control. This section of the tutorial describes how to provide labels that are properly associated with form controls. Later sections explain how to provide [instructions](../instructions), [validate user input](../validation), and [provide feedback](../notifications) to help users complete your form.

--- a/content/forms/notifications.md
+++ b/content/forms/notifications.md
@@ -17,7 +17,6 @@ navigation:
   previous: /tutorials/forms/validation/
   next: /tutorials/forms/multi-page/
 
-
 wcag_success_criteria:
   - 3.3.1
   - 3.3.3
@@ -50,6 +49,7 @@ Provide feedback to users about the results of their form submission, whether su
 {% include box.html type="end" %}
 {:/}
 
+{::options toc_levels="2,3,4" /}
 {% include_cached toc.html %}
 
 Notifications have to be concise and clear. In particular, error messages should be easy to understand and should provide simple instructions on how they can be resolved. Success messages are also important to confirm task completion.

--- a/content/menus/flyout.md
+++ b/content/menus/flyout.md
@@ -45,6 +45,7 @@ People with reduced dexterity, such as tremors, often have trouble operating fly
 {% include box.html type="end" %}
 {:/}
 
+{::options toc_levels="2,3,4" /}
 {% include_cached toc.html %}
 
 ## Indicate submenus

--- a/content/page-structure/content.md
+++ b/content/page-structure/content.md
@@ -27,7 +27,6 @@ contributing_participants:
   - see <a href="/WAI/tutorials/acknowledgements/">Acknowledgements</a>
 support: Developed by the Education and Outreach Working Group (<a href="https://www.w3.org/groups/wg/eowg">EOWG</a>). Developed with support from the <a href="https://www.w3.org/WAI/ACT/">WAI-ACT project</a>, co-funded by the <strong>European Commission <abbr title="Information Society Technologies">IST</abbr> Programme</strong>.
 
-
 wcag_success_criteria:
   - 1.3.1
 wcag_techniques:
@@ -47,6 +46,7 @@ Mark up website content semantically, so that the website is extensible. Valid s
 {% include box.html type="end" %}
 {:/}
 
+{::options toc_levels="2,3,4" /}
 {% include_cached toc.html %}
 
 ## Articles


### PR DESCRIPTION
The config file contains a kramdown rule that limits the generated table of contents to H2/H3 levels by default. That rule was misspelled and therefore not technically applied.

As discussed with @shawna-slh, we want to reinstate this default rule but keep displaying H2 to H4 sections in the following pages (we assume they are included on purpose).

- https://www.w3.org/WAI/tutorials/menus/flyout/
- https://www.w3.org/WAI/tutorials/page-structure/content/
- https://www.w3.org/WAI/tutorials/forms/labels/
- https://www.w3.org/WAI/tutorials/forms/instructions/
- https://www.w3.org/WAI/tutorials/forms/notifications/